### PR TITLE
#1 - Sending request headers and body in JettyClientSlice

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,11 @@ SOFTWARE.
       <artifactId>jetty-reactive-httpclient</artifactId>
       <version>1.1.4</version>
     </dependency>
+    <dependency>
+      <groupId>com.artipie</groupId>
+      <artifactId>asto</artifactId>
+      <version>0.23.3</version>
+    </dependency>
     <!-- Test only dependencies -->
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -92,12 +97,6 @@ SOFTWARE.
       <groupId>com.artipie</groupId>
       <artifactId>vertx-server</artifactId>
       <version>0.3.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.artipie</groupId>
-      <artifactId>asto</artifactId>
-      <version>0.23.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/artipie/http/client/jetty/JettyClientSlice.java
+++ b/src/main/java/com/artipie/http/client/jetty/JettyClientSlice.java
@@ -118,6 +118,12 @@ final class JettyClientSlice implements Slice {
      * @param headers Request headers.
      * @param body Request body.
      * @return Request built from parameters.
+     * @todo #1:30min Send request body in reactive way.
+     *  `JettyClientSlice` reads whole request body before sending. It is inefficient
+     *  for bigger requests. There is `ReactiveRequest.Content.fromPublisher` class in Jetty
+     *  client, but it seems to cause infinite blocks in tests.
+     *  Plus, it has other flows: adding mandatory `Content-Type` header
+     *  and `Transfer-Encoding: chunked`. So own implementation might be needed.
      */
     private CompletionStage<Request> request(
         final String line,

--- a/src/main/java/com/artipie/http/client/jetty/JettyClientSlice.java
+++ b/src/main/java/com/artipie/http/client/jetty/JettyClientSlice.java
@@ -23,18 +23,22 @@
  */
 package com.artipie.http.client.jetty;
 
+import com.artipie.asto.ext.PublisherAs;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.StandardRs;
+import hu.akarnokd.rxjava2.interop.SingleInterop;
 import io.reactivex.Flowable;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 import org.apache.http.client.utils.URIBuilder;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.Request;
+import org.eclipse.jetty.client.util.BytesContentProvider;
 import org.eclipse.jetty.reactive.client.ReactiveRequest;
 import org.reactivestreams.Publisher;
 
@@ -97,11 +101,13 @@ final class JettyClientSlice implements Slice {
         final Publisher<ByteBuffer> body
     ) {
         return new AsyncResponse(
-            Flowable.fromPublisher(
-                ReactiveRequest.newBuilder(this.request(line)).build().response(
-                    (response, rsbody) -> Flowable.just(StandardRs.EMPTY)
-                )
-            ).singleOrError()
+            this.request(line, headers, body).thenCompose(
+                request -> Flowable.fromPublisher(
+                    ReactiveRequest.newBuilder(request).build().response(
+                        (response, rsbody) -> Flowable.just(StandardRs.EMPTY)
+                    )
+                ).singleOrError().to(SingleInterop.get())
+            )
         );
     }
 
@@ -109,9 +115,15 @@ final class JettyClientSlice implements Slice {
      * Create request.
      *
      * @param line Request line.
+     * @param headers Request headers.
+     * @param body Request body.
      * @return Request built from parameters.
      */
-    private Request request(final String line) {
+    private CompletionStage<Request> request(
+        final String line,
+        final Iterable<Map.Entry<String, String>> headers,
+        final Publisher<ByteBuffer> body
+    ) {
         final RequestLineFrom req = new RequestLineFrom(line);
         final String scheme;
         if (this.secure) {
@@ -120,7 +132,7 @@ final class JettyClientSlice implements Slice {
             scheme = "http";
         }
         final URI uri = req.uri();
-        return this.client.newRequest(
+        final Request request = this.client.newRequest(
             new URIBuilder()
                 .setScheme(scheme)
                 .setHost(this.host)
@@ -129,5 +141,19 @@ final class JettyClientSlice implements Slice {
                 .setCustomQuery(uri.getQuery())
                 .toString()
         ).method(req.method().value());
+        for (final Map.Entry<String, String> header : headers) {
+            request.header(header.getKey(), header.getValue());
+        }
+        return new PublisherAs(body).bytes().thenApply(
+            bytes -> {
+                final Request result;
+                if (bytes.length > 0) {
+                    result = request.content(new BytesContentProvider(bytes));
+                } else {
+                    result = request;
+                }
+                return result;
+            }
+        );
     }
 }


### PR DESCRIPTION
Part of #1 
Sending request headers and body in `JettyClientSlice`.
Body is sent in non-reactive way because for faulty Publisher support in Jetty `HttpClient`.