### PR TITLE
#5 - Proxy support in JettyClientSlices

### DIFF
--- a/src/main/java/com/artipie/http/client/Settings.java
+++ b/src/main/java/com/artipie/http/client/Settings.java
@@ -166,6 +166,15 @@ public interface Settings {
         /**
          * Ctor.
          *
+         * @param prx Proxy.
+         */
+        public WithProxy(final Proxy prx) {
+            this(new Settings.Default(), prx);
+        }
+
+        /**
+         * Ctor.
+         *
          * @param origin Origin settings.
          * @param prx Proxy.
          */

--- a/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
+++ b/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
@@ -25,7 +25,10 @@ package com.artipie.http.client.jetty;
 
 import com.artipie.http.Slice;
 import com.artipie.http.client.ClientSlices;
+import com.artipie.http.client.Settings;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpProxy;
+import org.eclipse.jetty.client.Origin;
 
 /**
  * ClientSlices implementation using Jetty HTTP client as back-end.
@@ -56,7 +59,16 @@ public final class JettyClientSlices implements ClientSlices {
      * Ctor.
      */
     public JettyClientSlices() {
-        this.client = new HttpClient();
+        this(new Settings.Default());
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param settings Settings.
+     */
+    public JettyClientSlices(final Settings settings) {
+        this.client = create(settings);
     }
 
     /**
@@ -107,5 +119,21 @@ public final class JettyClientSlices implements ClientSlices {
      */
     private Slice slice(final boolean secure, final String host, final int port) {
         return new JettyClientSlice(this.client, secure, host, port);
+    }
+
+    /**
+     * Creates {@link HttpClient} from {@link Settings}.
+     *
+     * @param settings Settings.
+     * @return HTTP client built from settings.
+     */
+    private static HttpClient create(final Settings settings) {
+        final HttpClient result = new HttpClient();
+        settings.proxy().ifPresent(
+            proxy -> result.getProxyConfiguration().getProxies().add(
+                new HttpProxy(new Origin.Address(proxy.host(), proxy.port()), proxy.secure())
+            )
+        );
+        return result;
     }
 }

--- a/src/test/java/com/artipie/http/client/jetty/JettyClientSlicesTest.java
+++ b/src/test/java/com/artipie/http/client/jetty/JettyClientSlicesTest.java
@@ -23,6 +23,17 @@
  */
 package com.artipie.http.client.jetty;
 
+import com.artipie.http.Headers;
+import com.artipie.http.Slice;
+import com.artipie.http.client.Settings;
+import com.artipie.http.hm.RsHasBody;
+import com.artipie.http.rq.RequestLine;
+import com.artipie.http.rq.RqMethod;
+import com.artipie.http.rs.RsWithBody;
+import com.artipie.vertx.VertxSliceServer;
+import io.reactivex.Flowable;
+import io.vertx.reactivex.core.Vertx;
+import java.nio.ByteBuffer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.jupiter.api.Test;
@@ -36,7 +47,13 @@ import org.junit.jupiter.api.Test;
  *  `JettyClientSlice` instances, but do not check that they are configured
  *  with expected host, port and secure flag.
  *  These important properties should be covered with tests.
+ * @todo #5:30min Test support for secure proxy in `JettyClientSlices`.
+ *  There is a test in `JettyClientSlicesTest` checking that
+ *  non-secure proxy works in `JettyClientSlices`. It's needed to test
+ *  support for proxy working over HTTPS protocol.
+ * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 final class JettyClientSlicesTest {
 
     @Test
@@ -71,5 +88,32 @@ final class JettyClientSlicesTest {
             new JettyClientSlices().http("www.artipie.com", port),
             new IsInstanceOf(JettyClientSlice.class)
         );
+    }
+
+    @Test
+    void shouldSupportProxy() throws Exception {
+        final byte[] response = "response from proxy".getBytes();
+        final Slice slice = (line, headers, body) -> new RsWithBody(
+            Flowable.just(ByteBuffer.wrap(response))
+        );
+        try (VertxSliceServer server = new VertxSliceServer(Vertx.vertx(), slice)) {
+            final int port = server.start();
+            final JettyClientSlices client = new JettyClientSlices(
+                new Settings.WithProxy(new Settings.Proxy.Simple(false, "localhost", port))
+            );
+            try {
+                client.start();
+                MatcherAssert.assertThat(
+                    client.http("artipie.com").response(
+                        new RequestLine(RqMethod.GET, "/").toString(),
+                        Headers.EMPTY,
+                        Flowable.empty()
+                    ),
+                    new RsHasBody(response)
+                );
+            } finally {
+                client.stop();
+            }
+        }
     }
 }


### PR DESCRIPTION
Closes #5 
Proxy supported in `JettyClientSlices`.