### PR TITLE
#4 - Support for trust all setting in JettyClientSlices

### DIFF
--- a/src/main/java/com/artipie/http/client/Settings.java
+++ b/src/main/java/com/artipie/http/client/Settings.java
@@ -193,4 +193,52 @@ public interface Settings {
             return this.origin.trustAll();
         }
     }
+
+    /**
+     * Settings that add trust all setting to origin {@link Settings}.
+     *
+     * @since 0.1
+     */
+    final class WithTrustAll implements Settings {
+
+        /**
+         * Origin settings.
+         */
+        private final Settings origin;
+
+        /**
+         * Trust all setting.
+         */
+        private final boolean trust;
+
+        /**
+         * Ctor.
+         *
+         * @param trust Trust all setting.
+         */
+        public WithTrustAll(final boolean trust) {
+            this(new Settings.Default(), trust);
+        }
+
+        /**
+         * Ctor.
+         *
+         * @param origin Origin settings.
+         * @param trust Trust all setting.
+         */
+        public WithTrustAll(final Settings origin, final boolean trust) {
+            this.origin = origin;
+            this.trust = trust;
+        }
+
+        @Override
+        public Optional<Proxy> proxy() {
+            return this.origin.proxy();
+        }
+
+        @Override
+        public boolean trustAll() {
+            return this.trust;
+        }
+    }
 }

--- a/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
+++ b/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
@@ -29,6 +29,7 @@ import com.artipie.http.client.Settings;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 /**
  * ClientSlices implementation using Jetty HTTP client as back-end.
@@ -128,7 +129,7 @@ public final class JettyClientSlices implements ClientSlices {
      * @return HTTP client built from settings.
      */
     private static HttpClient create(final Settings settings) {
-        final HttpClient result = new HttpClient();
+        final HttpClient result = new HttpClient(new SslContextFactory.Client(settings.trustAll()));
         settings.proxy().ifPresent(
             proxy -> result.getProxyConfiguration().getProxies().add(
                 new HttpProxy(new Origin.Address(proxy.host(), proxy.port()), proxy.secure())

--- a/src/test/java/com/artipie/http/client/SettingsTest.java
+++ b/src/test/java/com/artipie/http/client/SettingsTest.java
@@ -27,6 +27,8 @@ import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.IsEqual;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests for {@link SettingsTest}.
@@ -80,6 +82,15 @@ final class SettingsTest {
         MatcherAssert.assertThat(
             new Settings.WithProxy(new Settings.Default(), proxy).proxy(),
             new IsEqual<>(Optional.of(proxy))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void withTrustAll(final boolean value) {
+        MatcherAssert.assertThat(
+            new Settings.WithTrustAll(value).trustAll(),
+            new IsEqual<>(value)
         );
     }
 }

--- a/src/test/java/com/artipie/http/client/jetty/JettyClientSlicesTest.java
+++ b/src/test/java/com/artipie/http/client/jetty/JettyClientSlicesTest.java
@@ -51,6 +51,12 @@ import org.junit.jupiter.api.Test;
  *  There is a test in `JettyClientSlicesTest` checking that
  *  non-secure proxy works in `JettyClientSlices`. It's needed to test
  *  support for proxy working over HTTPS protocol.
+ * @todo #5:30min Test support for `trustAll` setting in `JettyClientSlices`.
+ *  There is no test checking that `trustAll` setting is supported by `JettyClientSlices`.
+ *  To check that it is required to start an HTTP server with self-signed certificate
+ *  and see that client connects successfully and does not fail verification.
+ *  It should also be validated that client with `trustAll` setting disabled does not connect
+ *  to such server.
  * @checkstyle ClassDataAbstractionCouplingCheck (500 lines)
  */
 @SuppressWarnings("PMD.AvoidDuplicateLiterals")


### PR DESCRIPTION
Closes #4 
Support for trust all setting in `JettyClientSlices`.