### PR TITLE
#14 - Follow redirects support in JettyClientSlices

### DIFF
--- a/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
+++ b/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
@@ -148,6 +148,7 @@ public final class JettyClientSlices implements ClientSlices {
                 new HttpProxy(new Origin.Address(proxy.host(), proxy.port()), proxy.secure())
             )
         );
+        result.setFollowRedirects(settings.followRedirects());
         return result;
     }
 }


### PR DESCRIPTION
Closes #14 
Support for follow redirects in `JettyClientSlices`