### PR TITLE
#16 - Idle timeout support in JettyClientSlices

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>asto</artifactId>
-      <version>0.23.3</version>
+      <version>0.23.5</version>
     </dependency>
     <!-- Test only dependencies -->
     <dependency>

--- a/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
+++ b/src/main/java/com/artipie/http/client/jetty/JettyClientSlices.java
@@ -149,6 +149,7 @@ public final class JettyClientSlices implements ClientSlices {
             )
         );
         result.setFollowRedirects(settings.followRedirects());
+        result.setIdleTimeout(settings.idleTimeout());
         return result;
     }
 }


### PR DESCRIPTION
Part of #16 
Support for idle timeout setting in `JettyClientSlices`