### PR TITLE
#51 - Bearer support in GenericAuthenticator

### DIFF
--- a/src/main/java/com/artipie/http/client/auth/BasicAuthenticator.java
+++ b/src/main/java/com/artipie/http/client/auth/BasicAuthenticator.java
@@ -24,26 +24,42 @@
 package com.artipie.http.client.auth;
 
 import com.artipie.http.Headers;
+import com.artipie.http.headers.Authorization;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 /**
- * Authenticator for HTTP requests.
+ * Basic authenticator for given username and password.
  *
  * @since 0.3
  */
-public interface Authenticator {
+public final class BasicAuthenticator implements Authenticator {
 
     /**
-     * Anonymous authorization. Always returns empty headers set.
+     * Username.
      */
-    Authenticator ANONYMOUS = ignored -> CompletableFuture.completedFuture(Headers.EMPTY);
+    private final String username;
 
     /**
-     * Get authorization headers.
+     * Password.
+     */
+    private final String password;
+
+    /**
+     * Ctor.
      *
-     * @param headers Headers with requirements for authorization.
-     * @return Authorization headers.
+     * @param username Username.
+     * @param password Password.
      */
-    CompletionStage<Headers> authenticate(Headers headers);
+    public BasicAuthenticator(final String username, final String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public CompletionStage<Headers> authenticate(final Headers headers) {
+        return CompletableFuture.completedFuture(
+            new Headers.From(new Authorization.Basic(this.username, this.password))
+        );
+    }
 }

--- a/src/main/java/com/artipie/http/client/auth/GenericAuthenticator.java
+++ b/src/main/java/com/artipie/http/client/auth/GenericAuthenticator.java
@@ -24,6 +24,7 @@
 package com.artipie.http.client.auth;
 
 import com.artipie.http.Headers;
+import com.artipie.http.client.ClientSlices;
 import com.artipie.http.headers.WwwAuthenticate;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.StreamSupport;
@@ -39,16 +40,56 @@ public final class GenericAuthenticator implements Authenticator {
     /**
      * Basic authenticator used when required.
      */
-    private final Authenticator.Basic basic;
+    private final Authenticator basic;
+
+    /**
+     * Bearer authenticator used when required.
+     */
+    private final Authenticator bearer;
 
     /**
      * Ctor.
      *
+     * @param client Client slices.
+     */
+    public GenericAuthenticator(final ClientSlices client) {
+        this(
+            Authenticator.ANONYMOUS,
+            new BearerAuthenticator(client, new OAuthTokenFormat(), Authenticator.ANONYMOUS)
+        );
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param client Client slices.
      * @param username Username.
      * @param password Password.
      */
-    public GenericAuthenticator(final String username, final String password) {
-        this.basic = new Authenticator.Basic(username, password);
+    public GenericAuthenticator(
+        final ClientSlices client,
+        final String username,
+        final String password
+    ) {
+        this(
+            new BasicAuthenticator(username, password),
+            new BearerAuthenticator(
+                client,
+                new OAuthTokenFormat(),
+                new BasicAuthenticator(username, password)
+            )
+        );
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param basic Basic authenticator used when required.
+     * @param bearer Bearer authenticator used when required.
+     */
+    public GenericAuthenticator(final Authenticator basic, final Authenticator bearer) {
+        this.basic = basic;
+        this.bearer = bearer;
     }
 
     @Override
@@ -68,10 +109,15 @@ public final class GenericAuthenticator implements Authenticator {
      * @return Authorization headers.
      */
     public Authenticator authenticate(final WwwAuthenticate header) {
+        final Authenticator result;
         final String scheme = header.scheme();
         if ("Basic".equals(scheme)) {
-            return this.basic;
+            result = this.basic;
+        } else if ("Bearer".equals(scheme)) {
+            result = this.bearer;
+        } else {
+            throw new IllegalArgumentException(String.format("Unsupported scheme: %s", scheme));
         }
-        throw new IllegalArgumentException(String.format("Unsupported scheme: %s", scheme));
+        return result;
     }
 }

--- a/src/test/java/com/artipie/http/client/auth/BasicAuthenticatorTest.java
+++ b/src/test/java/com/artipie/http/client/auth/BasicAuthenticatorTest.java
@@ -36,13 +36,13 @@ import org.junit.jupiter.api.Test;
  *
  * @since 0.3
  */
-class AuthenticatorBasicTest {
+class BasicAuthenticatorTest {
 
     @Test
     void shouldProduceBasicHeader() {
         MatcherAssert.assertThat(
             StreamSupport.stream(
-                new Authenticator.Basic("Aladdin", "open sesame")
+                new BasicAuthenticator("Aladdin", "open sesame")
                     .authenticate(Headers.EMPTY)
                     .toCompletableFuture().join()
                     .spliterator(),


### PR DESCRIPTION
Part of #51 
Bearer scheme support in `GenericAuthenticator`.
`Authenticator.Basic` moved to upper class `BasicAuthenticator`