### PR TITLE
fix: remove asto dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,16 +55,12 @@ SOFTWARE.
     <dependency>
       <groupId>com.artipie</groupId>
       <artifactId>http</artifactId>
-      <version>0.16.1</version>
+      <version>v1.1.3</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-reactive-httpclient</artifactId>
       <version>1.1.10</version>
-    </dependency>
-    <dependency>
-      <groupId>com.artipie</groupId>
-      <artifactId>asto</artifactId>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>
@@ -75,6 +71,11 @@ SOFTWARE.
       <artifactId>javax.json</artifactId>
     </dependency>
     <!-- Test only dependencies -->
+    <dependency>
+      <groupId>org.cactoos</groupId>
+      <artifactId>cactoos</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>

--- a/src/main/java/com/artipie/http/client/auth/AuthClientSlice.java
+++ b/src/main/java/com/artipie/http/client/auth/AuthClientSlice.java
@@ -23,15 +23,16 @@
  */
 package com.artipie.http.client.auth;
 
-import com.artipie.asto.Content;
-import com.artipie.asto.ext.PublisherAs;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.client.misc.PublisherAs;
 import com.artipie.http.rs.RsStatus;
 import com.google.common.collect.Iterables;
+import io.reactivex.Flowable;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import org.reactivestreams.Publisher;
@@ -70,7 +71,9 @@ public final class AuthClientSlice implements Slice {
         final Iterable<Map.Entry<String, String>> headers,
         final Publisher<ByteBuffer> body) {
         return new AsyncResponse(
-            new PublisherAs(body).bytes().thenApply(Content.From::new).thenApply(
+            new PublisherAs(body).bytes().thenApply(
+                array -> Flowable.fromArray(ByteBuffer.wrap(Arrays.copyOf(array, array.length)))
+            ).thenApply(
                 copy -> connection -> this.auth.authenticate(Headers.EMPTY).thenCompose(
                     first -> this.origin.response(
                         line,

--- a/src/main/java/com/artipie/http/client/auth/BearerAuthenticator.java
+++ b/src/main/java/com/artipie/http/client/auth/BearerAuthenticator.java
@@ -23,15 +23,15 @@
  */
 package com.artipie.http.client.auth;
 
-import com.artipie.asto.Content;
-import com.artipie.asto.ext.PublisherAs;
 import com.artipie.http.Headers;
 import com.artipie.http.client.ClientSlices;
 import com.artipie.http.client.UriClientSlice;
+import com.artipie.http.client.misc.PublisherAs;
 import com.artipie.http.headers.Authorization;
 import com.artipie.http.headers.WwwAuthenticate;
 import com.artipie.http.rq.RequestLine;
 import com.artipie.http.rq.RqMethod;
+import io.reactivex.Flowable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.CompletableFuture;
@@ -103,7 +103,7 @@ public final class BearerAuthenticator implements Authenticator {
         return new AuthClientSlice(new UriClientSlice(this.client, realm), this.auth).response(
             new RequestLine(RqMethod.GET, String.format("?%s", query)).toString(),
             Headers.EMPTY,
-            Content.EMPTY
+            Flowable.empty()
         ).send(
             (status, headers, body) -> new PublisherAs(body).bytes()
                 .thenApply(this.format::token)

--- a/src/main/java/com/artipie/http/client/jetty/JettyClientSlice.java
+++ b/src/main/java/com/artipie/http/client/jetty/JettyClientSlice.java
@@ -23,11 +23,11 @@
  */
 package com.artipie.http.client.jetty;
 
-import com.artipie.asto.ext.PublisherAs;
 import com.artipie.http.Headers;
 import com.artipie.http.Response;
 import com.artipie.http.Slice;
 import com.artipie.http.async.AsyncResponse;
+import com.artipie.http.client.misc.PublisherAs;
 import com.artipie.http.headers.Header;
 import com.artipie.http.rq.RequestLineFrom;
 import com.artipie.http.rs.RsFull;

--- a/src/main/java/com/artipie/http/client/misc/PublisherAs.java
+++ b/src/main/java/com/artipie/http/client/misc/PublisherAs.java
@@ -1,0 +1,125 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.artipie.http.client.misc;
+
+import hu.akarnokd.rxjava2.interop.SingleInterop;
+import io.reactivex.Flowable;
+import io.reactivex.Single;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletionStage;
+import org.reactivestreams.Publisher;
+
+/**
+ * Read bytes from publisher to memory.
+ * Using this class keep in mind that it reads ByteBuffer from publisher into memory and is not
+ * suitable for large content.
+ * @since 0.4
+ */
+public final class PublisherAs {
+
+    /**
+     * Content to read bytes from.
+     */
+    private final Publisher<ByteBuffer> content;
+
+    /**
+     * Ctor.
+     * @param content Content
+     */
+    public PublisherAs(final Publisher<ByteBuffer> content) {
+        this.content = content;
+    }
+
+    /**
+     * Reads bytes from content into memory.
+     * @return Byte array as CompletionStage
+     */
+    public CompletionStage<byte[]> bytes() {
+        return this.single().map(PublisherAs::bytes).to(SingleInterop.get());
+    }
+
+    /**
+     * Reads bytes from content as string.
+     * @param charset Charset to read string
+     * @return String as CompletionStage
+     */
+    public CompletionStage<String> string(final Charset charset) {
+        return this.bytes().thenApply(bytes -> new String(bytes, charset));
+    }
+
+    /**
+     * Reads bytes from content as {@link StandardCharsets#US_ASCII} string.
+     * @return String as CompletionStage
+     */
+    public CompletionStage<String> asciiString() {
+        return this.string(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Concatenates all buffers into single one.
+     *
+     * @return Single buffer.
+     */
+    private Single<ByteBuffer> single() {
+        return Flowable.fromPublisher(this.content).reduce(
+            ByteBuffer.allocate(0),
+            (left, right) -> {
+                right.mark();
+                final ByteBuffer result;
+                if (left.capacity() - left.limit() >= right.limit()) {
+                    left.position(left.limit());
+                    left.limit(left.limit() + right.limit());
+                    result = left.put(right);
+                } else {
+                    result = ByteBuffer.allocate(
+                        2 * Math.max(left.capacity(), right.capacity())
+                    ).put(left).put(right);
+                }
+                right.reset();
+                result.flip();
+                return result;
+            }
+        );
+    }
+
+    /**
+     * Obtain remaining bytes.
+     * <p>
+     * Read all remaining bytes from the buffer and reset position back after
+     * reading.
+     * </p>
+     * @param buf Bytes to read
+     * @return Remaining bytes.
+     */
+    private static byte[] bytes(final ByteBuffer buf) {
+        final byte[] bytes = new byte[buf.remaining()];
+        buf.mark();
+        buf.get(bytes);
+        buf.reset();
+        return bytes;
+    }
+
+}

--- a/src/main/java/com/artipie/http/client/misc/package-info.java
+++ b/src/main/java/com/artipie/http/client/misc/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Artipie
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * HTTP client misc classes.
+ *
+ * @since 0.4
+ */
+package com.artipie.http.client.misc;


### PR DESCRIPTION
Closes #75 
Removed asto dependency. As it's still necessary to read `Publisher<ByteBuffer>` into bytes here, I've added corresponding class.