### PR TITLE
chore: add GitHub action for update license year

### DIFF
--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -1,8 +1,8 @@
-name: Update copyright year in license file and license header of all files
+name: Update copyright year
 
 #on:
 #  schedule:
-#    - cron: "0 3 1 1 *"
+#  - cron: '0 1 22 * *'
 
 on: workflow_dispatch
 
@@ -16,6 +16,8 @@ jobs:
       - uses: FantasticFiasco/action-update-license-year@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          path: LICENSE*
+          commitTitle: "chore: update year in license file"
 
   source:
     needs: license
@@ -28,3 +30,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: src/**/*.java
+          commitTitle: "chore: update year in license header"

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -7,7 +7,18 @@ name: Update copyright year in license file and license header of all files
 on: workflow_dispatch
 
 jobs:
-  run:
+  license:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: FantasticFiasco/action-update-license-year@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  source:
+    needs: license
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -1,0 +1,19 @@
+name: Update copyright year in license file and license header of all files
+
+#on:
+#  schedule:
+#    - cron: "0 3 1 1 *"
+
+on: workflow_dispatch
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: FantasticFiasco/action-update-license-year@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: src/**/*.java

--- a/.github/workflows/update-copyright-years.yml
+++ b/.github/workflows/update-copyright-years.yml
@@ -1,10 +1,8 @@
 name: Update copyright year
 
-#on:
-#  schedule:
-#  - cron: '0 1 22 * *'
-
-on: workflow_dispatch
+on:
+  schedule:
+  - cron: '0 1 22 * *'
 
 jobs:
   license:
@@ -17,7 +15,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: LICENSE*
-          commitTitle: "chore: update year in license file"
+          commitTitle: "chore: update year in LICENSE file"
 
   source:
     needs: license


### PR DESCRIPTION
add GitHub action which check for current year and make PR for update year in LICENCE file and in license header at 01:00 UTC on the 22nd of every month

close: https://github.com/artipie/artipie/issues/1035
